### PR TITLE
Docker: Only use the Docker DB host if specified.

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@ development: &default
   pool: 5
   username: postgres
   password:
-  host: db
+  host: <%= (ENV['DB_HOST'] || 'localhost').to_json %>
 
 test:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - server
       - --binding=0.0.0.0
       - --port=3000
+    environment:
+      DB_HOST: db
     volumes:
       - .:/planner
     ports:


### PR DESCRIPTION
Works on Docker, but I can't test simple non-Docker development, so could you test it and merge if you're happy?