### PR TITLE
feature/handle virtual workshops

### DIFF
--- a/app/controllers/concerns/invitation_controller_concerns.rb
+++ b/app/controllers/concerns/invitation_controller_concerns.rb
@@ -21,13 +21,12 @@ module InvitationControllerConcerns
                              notice: t('messages.invitations.rsvped_to_other_workshop'))
       end
 
-      @workshop = WorkshopPresenter.new(@invitation.workshop)
+      @workshop = WorkshopPresenter.decorate(@invitation.workshop)
+
       if (@invitation.for_student? && @workshop.student_spaces?) || (@invitation.for_coach? && @workshop.coach_spaces?)
         @invitation.update(attending: true, rsvp_time: Time.zone.now)
         @invitation.waiting_list.destroy if @invitation.waiting_list.present?
-        WorkshopInvitationMailer.attending(@invitation.workshop,
-                                           @invitation.member,
-                                           @invitation).deliver_now
+        @workshop.send_attending_email(@invitation)
 
         redirect_back(fallback_location: invitation_path(@invitation),
                       notice: t('messages.accepted_invitation', name: @invitation.member.name))

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -3,8 +3,7 @@ class WorkshopsController < ApplicationController
   before_action :set_workshop, only: %i[show rsvp]
 
   def show
-    @workshop = WorkshopPresenter.new(@workshop)
-    @host_address = AddressPresenter.new(@workshop.host.address) if @workshop.has_host?
+    @workshop = WorkshopPresenter.decorate(@workshop)
 
     render 'virtual_workshops/show' if @workshop.virtual?
   end
@@ -13,13 +12,13 @@ class WorkshopsController < ApplicationController
     redirect_to :back, notice: t('workshops.registration_not_open') unless @workshop.invitable_yet?
 
     if role_params.nil?
-      @invitation = WorkshopInvitation.find_by(workshop: @workshop, member: current_user, attending: true)
+      @invitation = find_attending_invitation(@workshop, current_user)
     else
-      if @workshop.attendee?(current_user) || @workshop.waitlisted?(current_user)
+      if user_attending_or_waitinglisted?(@workshop, current_user)
         return redirect_to :back, notice: t('workshops.already_wish_to_attend')
       end
 
-      @invitation = WorkshopInvitation.find_or_create_by(workshop: @workshop, member: current_user, role: role_params)
+      @invitation = find_or_create_invitation(@workshop, current_user, role_params)
     end
 
     redirect_to invitation_path(@invitation)
@@ -33,5 +32,19 @@ class WorkshopsController < ApplicationController
 
   def role_params
     params[:role]
+  end
+
+  def find_attending_invitation(workshop, user)
+    WorkshopInvitation.find_by(workshop: workshop, member: user, attending: true)
+  end
+
+  def find_or_create_invitation(workshop, user, role)
+    WorkshopInvitation.find_or_create_by(workshop: workshop,
+                                         member: user,
+                                         role: role)
+  end
+
+  def user_attending_or_waitinglisted?(workshop, user)
+    workshop.attendee?(user) || workshop.waitlisted?(user)
   end
 end

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -5,6 +5,8 @@ class WorkshopsController < ApplicationController
   def show
     @workshop = WorkshopPresenter.new(@workshop)
     @host_address = AddressPresenter.new(@workshop.host.address) if @workshop.has_host?
+
+    render 'virtual_workshops/show' if @workshop.virtual?
   end
 
   def rsvp

--- a/app/mailers/workshop_invitation_mailer.rb
+++ b/app/mailers/workshop_invitation_mailer.rb
@@ -26,6 +26,20 @@ class WorkshopInvitationMailer < ActionMailer::Base
     reminder_setup(workshop, member, invitation, subject)
   end
 
+  def attending_virtual(workshops, member, invitation, waiting_list = false)
+    @workshop = VirtualWorkshopPresenter.new(workshops)
+    @member = member
+    @invitation = invitation
+    @waiting_list = waiting_list
+
+    subject = "Attendance Confirmation: #{I18n.t('workshop.virtual.title',
+                                                  chapter: @workshop.chapter.name,
+                                                  date: humanize_date(@workshop.date_and_time))}"
+
+    mail(mail_args(member, subject, @workshop.chapter.email), &:html)
+  end
+
+
   def change_of_details(workshop, sponsor, member, invitation, title = 'Change of details')
     @workshop = workshop
     @sponsor = sponsor

--- a/app/presenters/virtual_workshop_presenter.rb
+++ b/app/presenters/virtual_workshop_presenter.rb
@@ -23,6 +23,10 @@ class VirtualWorkshopPresenter < WorkshopPresenter
     virtual_workshop_spaces?
   end
 
+  def send_attending_email(invitation)
+    WorkshopInvitationMailer.attending_virtual(model, invitation.member, invitation).deliver_now
+  end
+
   private
 
   def virtual_workshop_spaces?

--- a/app/presenters/virtual_workshop_presenter.rb
+++ b/app/presenters/virtual_workshop_presenter.rb
@@ -1,0 +1,31 @@
+class VirtualWorkshopPresenter < WorkshopPresenter
+  def title
+    I18n.t('workshops.virtual.title', chapter: chapter.name)
+  end
+
+  def attending_and_available_student_spots
+    "#{attending_students.length}/#{student_spaces}"
+  end
+
+  def attending_and_available_coach_spots
+    "#{attending_coaches.length}/#{coach_spaces}"
+  end
+
+  def student_spaces?
+    student_spaces > attending_students.length
+  end
+
+  def coach_spaces?
+    coach_spaces > attending_coaches.length
+  end
+
+  def spaces?
+    virtual_workshop_spaces?
+  end
+
+  private
+
+  def virtual_workshop_spaces?
+    coach_spaces? || student_spaces?
+  end
+end

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -12,6 +12,10 @@ class WorkshopPresenter < EventPresenter
     I18n.t('workshops.title', host: venue.name)
   end
 
+  def address
+    AddressPresenter.new(venue.address)
+  end
+
   def attending_and_available_student_spots
     "#{attending_students.count}/#{venue.seats})"
   end
@@ -81,6 +85,10 @@ class WorkshopPresenter < EventPresenter
   def distance_of_time
     return "(#{distance_of_time_in_words_to_now(date_and_time)} ago)" if past?
     "(in #{distance_of_time_in_words_to_now(date_and_time)})"
+  end
+
+  def send_attending_email(invitation)
+    WorkshopInvitationMailer.attending(model, invitation.member, invitation).deliver_now
   end
 
   private

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -66,7 +66,16 @@ class WorkshopPresenter < EventPresenter
             "(in #{distance_of_time_in_words_to_now(date_and_time)})"
   end
 
+  def spaces?
+    return super unless model.virtual?
+    virtual_workshop_spaces?
+  end
+
   private
+
+  def virtual_workshop_spaces?
+    model.coach_spaces > model.attending_coaches.length || model.student_spaces > model.attending_students.length
+  end
 
   def students_checklist
     model.attending_students.order('note asc').each_with_index.map do |a, pos|

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -43,6 +43,16 @@ class WorkshopPresenter < EventPresenter
     I18n.l(model.time, format: :time)
   end
 
+  def end_time
+    I18n.l(model.ends_at, format: :time)
+  end
+
+  def start_and_end_time
+    start_and_end_time = time
+    start_and_end_time << " - #{end_time}" if model.ends_at.present?
+    start_and_end_time
+  end
+
   def path
     Rails.application.routes.url_helpers.workshop_path(model)
   end

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -3,6 +3,23 @@ class WorkshopPresenter < EventPresenter
   include ActionView::Context
   include ActionView::Helpers::DateHelper
 
+  def self.decorate(workshop)
+    return VirtualWorkshopPresenter.new(workshop) if workshop.virtual?
+    WorkshopPresenter.new(workshop)
+  end
+
+  def title
+    I18n.t('workshops.title', host: venue.name)
+  end
+
+  def attending_and_available_student_spots
+    "#{attending_students.count}/#{venue.seats})"
+  end
+
+  def attending_and_available_coach_spots
+    "#{attending_coaches.count}/#{venue.coach_spots})"
+  end
+
   def venue
     model.host
   end
@@ -62,20 +79,11 @@ class WorkshopPresenter < EventPresenter
   end
 
   def distance_of_time
-    past? ? "(#{distance_of_time_in_words_to_now(date_and_time)} ago)" :
-            "(in #{distance_of_time_in_words_to_now(date_and_time)})"
-  end
-
-  def spaces?
-    return super unless model.virtual?
-    virtual_workshop_spaces?
+    return "(#{distance_of_time_in_words_to_now(date_and_time)} ago)" if past?
+    "(in #{distance_of_time_in_words_to_now(date_and_time)})"
   end
 
   private
-
-  def virtual_workshop_spaces?
-    model.coach_spaces > model.attending_coaches.length || model.student_spaces > model.attending_students.length
-  end
 
   def students_checklist
     model.attending_students.order('note asc').each_with_index.map do |a, pos|

--- a/app/views/admin/workshops/_form.html.haml
+++ b/app/views/admin/workshops/_form.html.haml
@@ -2,6 +2,11 @@
   .row
     .medium-6.columns
       = f.association :chapter, as: :select, collection: Chapter.available_to_user(current_user)
+
+  .row
+    .medium-6.columns
+      = f.input :virtual, as: :boolean
+
   .row
     .medium-6.columns.admin_margin
       = f.input :local_date, label: "Date", as: :string, required: true, input_html: { data: { value: @workshop.date_and_time.try(:strftime, '%d/%m/%Y') } }
@@ -11,11 +16,11 @@
     .large-3.columns
       = f.input :ends_at, as: :string, required: true, input_html: { data: { value: @workshop.ends_at.try(:strftime, '%H:%M') } }
   .row
-    .medium-6.columns
-      = f.input :host, as: :select, required: true, collection: Sponsor.all, include_blank: true, selected: (@workshop.host.id rescue '')
+    .medium-6.columns#host
+      = f.input :host, as: :select, collection: Sponsor.all, include_blank: true, selected: (@workshop.host.id rescue '')
   .row
     .medium-6.columns.admin_margin
-      = f.association :sponsors, required: true
+      = f.association :sponsors
   %br
   .row
     .large-6.columns

--- a/app/views/invitation/_coach.html.haml
+++ b/app/views/invitation/_coach.html.haml
@@ -12,5 +12,4 @@
   - if @workshop.virtual?
     = t('workshop.virtual.invitation.shared_intro_3_html', email_link: mail_to(@workshop.chapter.email, @workshop.chapter.email))
   - else
-    = t('coaches.food')
-    #{mail_to @invitation.workshop.chapter.email, @invitation.workshop.chapter.email}.
+    %p= t('workshop.invitation.shared_intro_4_html', email_link: mail_to(@workshop.chapter.email, @workshop.chapter.email).html_safe)

--- a/app/views/invitation/_coach.html.haml
+++ b/app/views/invitation/_coach.html.haml
@@ -9,5 +9,8 @@
   = t('coaches.unable_attend')
 
 %p
-  = t('coaches.food')
-  #{mail_to @invitation.workshop.chapter.email, @invitation.workshop.chapter.email}.
+  - if @workshop.virtual?
+    = t('workshop.virtual.invitation.shared_intro_3_html', email_link: mail_to(@workshop.chapter.email, @workshop.chapter.email))
+  - else
+    = t('coaches.food')
+    #{mail_to @invitation.workshop.chapter.email, @invitation.workshop.chapter.email}.

--- a/app/views/invitation/_student.html.haml
+++ b/app/views/invitation/_student.html.haml
@@ -1,7 +1,7 @@
-%p In our workshops, you will get to go through any of our available tutorials, ask for programming advice or get help on your own projects.
-
-%p In case you are unable to attend after you RSVP, please make sure you come back and update your attendance. We have limited space and do a coaches request depending on the number of attending students.
-
-%p Please make sure you <b>bring your laptop</b> with you.
-
-%p PS: There will also be food at the workshop. We always make an effort to have vegetarian, vegan and gluten-free options available. If you have any other dietary requirements, send us email at #{mail_to @invitation.workshop.chapter.email, @invitation.workshop.chapter.email}.
+%p= t('workshop.invitation.student_intro_1')
+%p= t('workshop.invitation.student_intro_2')
+- if @workshop.virtual?
+  %p= t('workshop.virtual.invitation.shared_intro_3_html', email_link: mail_to(@workshop.chapter.email, @workshop.chapter.email))
+- else
+  %p= t('workshop.invitation.student_intro_3_html')
+  %p= t('workshop.invitation.student_intro_4_html', email_link: mail_to(@workshop.chapter.email, @workshop.chapter.email).html_safe)

--- a/app/views/invitation/_student.html.haml
+++ b/app/views/invitation/_student.html.haml
@@ -4,4 +4,4 @@
   %p= t('workshop.virtual.invitation.shared_intro_3_html', email_link: mail_to(@workshop.chapter.email, @workshop.chapter.email))
 - else
   %p= t('workshop.invitation.student_intro_3_html')
-  %p= t('workshop.invitation.student_intro_4_html', email_link: mail_to(@workshop.chapter.email, @workshop.chapter.email).html_safe)
+  %p= t('workshop.invitation.shared_intro_4_html', email_link: mail_to(@workshop.chapter.email, @workshop.chapter.email).html_safe)

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -20,7 +20,7 @@
 
   .row
     .medium-7.large-8.columns
-      %p
+      %p#introduction
         Hi #{@invitation.member.name},
         = render partial: @invitation.role.downcase
 
@@ -72,16 +72,32 @@
 
 .stripe.reverse#info
   .row
-    = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @workshop.address}
-
     .small-12.column
-      %h3 Sponsors
-      %ul.row.no-bullet
-        - @workshop.sponsors.each do |sponsor|
-          %li.small-4.columns
-            = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
-            %p
-              = link_to sponsor.name, sponsor.website
+      %h4= t('workshop.invitation.info')
+      - if @workshop.description?
+        %p.lead
+          = @workshop.description
+      - if @workshop.virtual? &&  @invitation.attending.eql?(true)
+        %h4= t('workshop.virtual.invitation.info.title')
+        %ol
+          %li= t('workshop.virtual.invitation.info.line_1_html', slack_link: link_to(t('social_media_links.slack_html')))
+          %li= t('workshop.virtual.invitation.info.line_2_html', channel: link_to('workshop channel', 'link' ))
+
+  - unless @workshop.virtual?
+    .row
+      = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @workshop.address}
+
+- if @workshop.sponsors.any?
+  .stripe.reverse#sponsors
+    .row
+      .small-12.column
+        %h3 Sponsors
+        %ul.row.no-bullet
+          - @workshop.sponsors.each do |sponsor|
+            %li.small-4.columns
+              = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
+              %p
+                = link_to sponsor.name, sponsor.website
 
 .stripe.reverse
   = render partial: 'members/organisers_grid', locals: { members: @workshop.organisers, show_info: true }

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -72,7 +72,7 @@
 
 .stripe.reverse
   .row
-    = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @host_address}
+    = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @workshop.address}
 
     .small-12.column
       %h3 Sponsors

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -4,11 +4,11 @@
   .row
     .large-12.columns
       %h2
-        Workshop at #{@workshop.host.name}
+        = @workshop.title
         %br
         %small #{humanize_date(@workshop.date_and_time, with_time: true)} #{@workshop.distance_of_time}
       - if @workshop.date_and_time.past?
-        %label.label.warning This event has already taken place.
+        %label.label.warning= t('workshops.already_taken_place')
 .alert-box.info
   .row
     .large-12.columns
@@ -27,7 +27,7 @@
     .medium-5.large-4.columns
       .panel
         - if @workshop.past?
-          %em This workshop has already taken place.
+          %em= t('workshops.already_taken_place')
         - else
           - if @invitation.attending.eql?(true)
             - if @invitation.for_student?
@@ -41,7 +41,7 @@
               = link_to "I can no longer attend", reject_invitation_url(@invitation), class: "expand button small alert"
             - else
               %p
-                If you can't make it or plan to arrive late please let us know by sending an email to #{@invitation.workshop.chapter.email}
+                = t('workshop.invitation.cant_make_it_note', email: @workshop.chapter.email)
           - elsif @invitation.member.banned?
             %p
               %label.label.warning Your account has been suspended.
@@ -70,7 +70,7 @@
           Read our #{link_to "attendance policy", attendance_policy_path}.
 
 
-.stripe.reverse
+.stripe.reverse#info
   .row
     = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @workshop.address}
 
@@ -89,9 +89,9 @@
 .stripe.reverse
   .row
     .medium-6.columns
-      %h4 Students (#{@invitation.workshop.attending_students.count}/#{@invitation.workshop.host.seats})
+      %h4 Students (#{@workshop.attending_and_available_student_spots})
       %ul.attendances.no-bullet
-        - @invitation.workshop.attending_students.each do |invitation|
+        - @workshop.attending_students.each do |invitation|
           %li.attendance
             .row
               .small-2.columns
@@ -102,9 +102,9 @@
                 .subheader=invitation.note
             %br
     .medium-6.columns
-      %h4 Coaches (#{@invitation.workshop.attending_coaches.count}/#{@invitation.workshop.host.coach_spots})
+      %h4 Coaches (#{@workshop.attending_and_available_coach_spots})
       %ul.attendances.no-bullet
-        - @invitation.workshop.attending_coaches.each do |invitation|
+        - @workshop.attending_coaches.each do |invitation|
           %li.attendance
             .row
               .small-2.columns

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -16,16 +16,8 @@
 
 
 .stripe.reverse
-  - if @announcements.present?
-    .row
-      .large-12.columns
-        %br
-          .alert-box.info{ "data-alert" => true }
-            =link_to "#", class: 'close' do
-              &times;
-            %ul.no-bullet
-              - @announcements.each do |announcement|
-                %li= dot_markdown(announcement.message)
+  = render partial: 'shared/announcements', locals: { announcements: @announcements }
+
   .row
     .medium-7.large-8.columns
       %p

--- a/app/views/members/_organisers_grid.html.haml
+++ b/app/views/members/_organisers_grid.html.haml
@@ -1,4 +1,4 @@
-.row
+.row#organisers
   .large-12.columns
     .text-center
       %h3= t('events.organisers')

--- a/app/views/shared/_announcements.html.haml
+++ b/app/views/shared/_announcements.html.haml
@@ -1,0 +1,10 @@
+- if announcements.present?
+  .row
+    .large-12.columns
+      %br
+        .alert-box.info{ "data-alert" => true }
+          =link_to "#", class: 'close' do
+            &times;
+          %ul.no-bullet
+            - announcements.each do |announcement|
+              %li= dot_markdown(announcement.message)

--- a/app/views/shared/_venue.html.haml
+++ b/app/views/shared/_venue.html.haml
@@ -1,21 +1,23 @@
-.small-12.column
-  %h3 Venue
-.medium-6.columns
-  %p
-    %strong= venue.name
-    %br
-      = address.to_html
-
-  - if address.directions
+#venue
+  .small-12.column
+    %h3 Venue
+  .medium-6.columns
     %p
-      %strong Directions:
-      = address.directions
+      %strong= venue.name
+      %br
+        #address
+          = address.to_html
 
-  - if venue.accessibility_info
-    %p
-      %strong Accessibility information:
-      = venue.accessibility_info
+    - if address.directions
+      %p
+        %strong Directions:
+        = address.directions
 
-.medium-6.columns
-  %iframe{ width: '100%', height: '350', frameborder: '0', scrolling: 'no', marginheight: '0', marginwidth: '0', src: %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{address.for_map}&ie=UTF8&t=m&z=15&output=embed} }
-  = link_to "View larger map", %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{address.for_map}&ie=UTF8&hq=&t=m&z=15}, style: "color:#0000FF;text-align:left"
+    - if venue.accessibility_info
+      %p
+        %strong Accessibility information:
+        = venue.accessibility_info
+
+  .medium-6.columns
+    %iframe{ width: '100%', height: '350', frameborder: '0', scrolling: 'no', marginheight: '0', marginwidth: '0', src: %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{address.for_map}&ie=UTF8&t=m&z=15&output=embed} }
+    = link_to "View larger map", %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{address.for_map}&ie=UTF8&hq=&t=m&z=15}, style: "color:#0000FF;text-align:left"

--- a/app/views/virtual_workshops/_meta_tags.html.haml
+++ b/app/views/virtual_workshops/_meta_tags.html.haml
@@ -1,0 +1,17 @@
+- content_for :meta_tags do
+  - title = "Virtual Workshop for #{workshop.chapter.name}"
+  - twitter_description = "codebar #{workshop.chapter.name} virtual  workshop on #{humanize_date(workshop.date_and_time, with_time: true)}"
+  - slack_description = "codebar #{workshop.chapter.name} virtual workshop"
+  %meta{ property: 'twitter:card', content: 'summary' }
+  %meta{ property: 'twitter:image', content: 'https://codebar.io/images/twitter-summary-card-image.png' }
+  %meta{ property: 'twitter:site', content: '@codebar' }
+  %meta{ property: 'twitter:title', content: title }
+  %meta{ property: 'twitter:description', content: twitter_description }
+  %meta{ property: 'twitter:image:alt', content: 'codebar logo' }
+  %meta{ property: 'og:title', content: title }
+  %meta{ property: 'og:description', content: slack_description }
+  %meta{ property: 'og:image', content: 'https://codebar.io/images/twitter-summary-card-image.png' }
+  %meta{ name: 'twitter:label1', value: "Where"}
+  %meta{ name: 'twitter:data1', value: "online" }
+  %meta{ name: 'twitter:label2', value: "When"}
+  %meta{ name: 'twitter:data2', value: "#{humanize_date(workshop.date_and_time, with_time: true)}" }

--- a/app/views/virtual_workshops/show.html.haml
+++ b/app/views/virtual_workshops/show.html.haml
@@ -1,0 +1,46 @@
+- title t('workshop.virtual.title', chapter: @workshop.chapter.name, date: humanize_date(@workshop.date_and_time))
+
+= render partial: 'virtual_workshops/meta_tags', locals: { workshop: @workshop }
+
+.stripe-reverse
+  .row
+    .large-12.columns
+      %h2
+        = t('workshops.virtual.title', chapter: @workshop.chapter.name)
+        %br
+        %small #{humanize_date(@workshop.date_and_time)} #{@workshop.distance_of_time}
+        #workshop-time.time
+          %i.material-icons
+            access_time
+          = @workshop.start_and_end_time
+      - if @workshop.date_and_time.past?
+        %label.label.warning= t('workshops.already_taken_place')
+
+  %section#banner
+    .row
+      .medium-12.columns
+        %p.lead
+          = t("workshops.virtual.lead")
+        %p.lead
+          = t("workshops.virtual.intro", chapter_email: @workshop.chapter.email)
+        %p.lead.description
+          = sanitize(@workshop.description)
+
+        - unless current_user and current_user.banned?
+          = render 'workshops/actions'
+
+- if @workshop.sponsors.any?
+  .stripe.reverse
+    .row
+      #sponsors
+        .small-12.column
+          %h3= t('events.sponsors')
+          %ul.row.no-bullet
+            - @workshop.sponsors.each do |sponsor|
+              %li.small-4.columns
+                = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
+                %p
+                  = link_to sponsor.name, sponsor.website
+
+.stripe.reverse
+  = render partial: 'members/organisers_grid', locals: { members: @workshop.organisers, show_info: false }

--- a/app/views/workshop_invitation_mailer/attending_virtual.html.haml
+++ b/app/views/workshop_invitation_mailer/attending_virtual.html.haml
@@ -1,0 +1,52 @@
+= render partial: 'shared_mailers/header', locals: { title: 'Workshop Attendance Confirmation' }
+%body{ bgcolor: '#FFFFFF' }
+
+  = render partial: 'shared_mailers/body_header', locals: { title: 'Workshop Attendance Confirmation' }
+
+  %table{ class: 'body-wrap'}
+    %tr
+      %td
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
+
+        .content
+          %table
+            %tr
+              %td
+                %h3 Hi #{@member.name},
+                %p.lead
+                  - if @waiting_list
+                    A spot became available and your attendance has now been confirmed.
+                  - else
+                    Your spot has been confirmed.
+                    - if @invitation.role.eql?('Student')
+                      %p If you haven't already, please remember to let us know what you will be working on through the invitation. Projects that involve specific frameworks, libraries, or languages that are not part of the codebar tutorials (anything other than Ruby or Javascript) are welcome, but we cannot guarantee that a coach will be available to help you. We recommend having a backup option to work on, such as codebar tutorials or katas (codewars.com or exercism.io). See you at our workshop!
+                  %p
+                    If you can no longer make it, please cancel your invitation <strong>before 15:00</strong> on the day of the workshop.
+                    <a href='https://codebar.io/student-guide#attendance'>We have a three-strikes attendance policy for no-shows.</a>
+                  %p
+                    Please remember that removing the calendar entry will not cancel your invitation RSVP.
+
+        .content
+          %table{ bgcolor: '#FFFFFF' }
+            %tr
+              %td
+                %h4
+                  Workshop
+                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+
+        .content
+          %table
+            %tr
+              %td
+                %h3 Organisers
+                %ul
+                  - @workshop.organisers.each do |organiser|
+                    %li
+                      = organiser.full_name
+
+        .content
+          = render partial: 'shared_mailers/social'
+      %td
+
+  = render partial: 'shared_mailers/footer'

--- a/app/views/workshops/_actions.html.haml
+++ b/app/views/workshops/_actions.html.haml
@@ -2,17 +2,16 @@
   %p
     %label.label.info= t('workshops.not_open_for_rsvp')
 - else
-  - if @workshop.past?
-    - unless logged_in?
-      %p Sign up to be invited to future events.
+  - if @workshop.past? and !logged_in?
+    %p= t('workshops.sign_up_to_be_invited')
   - else
     - if logged_in?
-      - if @workshop.attendee? current_user
-        %p You are attending this event.
-      - elsif @workshop.waitlisted? current_user
-        %p You are on the waiting List.
-      - elsif !@workshop.spaces?
-        %p Unfortunately this workshop is full, but do join the waiting list as spots open up in the lead up to the workshop.
+      - if @workshop.attendee?(current_user)
+        %p= t('workshops.already_attending')
+      - elsif @workshop.waitlisted?(current_user)
+        %p=t('workshops.on_waiting_list')
+      - elsif(!@workshop.spaces?)
+        %p= t('workshops.no_spaces_available')
 
 - if logged_in? && @workshop.future? && (@workshop.invitable || @workshop.open_for_rsvp?)
   - if @workshop.attendee?(current_user)

--- a/app/views/workshops/_workshop_actions.html.haml
+++ b/app/views/workshops/_workshop_actions.html.haml
@@ -1,5 +1,6 @@
 - if !@workshop.invitable_yet?
-  %p This workshop is not yet open for RSVP.
+  %p
+    %label.label.info= t('workshops.not_open_for_rsvp')
 - else
   - if @workshop.past?
     - unless logged_in?

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -6,7 +6,7 @@
   .row
     .large-12.columns
       %h2
-        Workshop at #{@workshop.host.name}
+        = t('workshops.title', host: @workshop.host.name)
         %br
         %small #{humanize_date(@workshop.date_and_time)} #{@workshop.distance_of_time}
         #workshop-time.time
@@ -28,7 +28,7 @@
 
 .stripe.reverse
   .row
-    = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @host_address}
+    = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @workshop.address}
 
     #sponsors
       .small-12.column

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -30,14 +30,15 @@
   .row
     = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @host_address}
 
-    .small-12.column
-      %h3 Sponsors
-      %ul.row.no-bullet
-        - @workshop.sponsors.each do |sponsor|
-          %li.small-4.columns
-            = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
-            %p
-              = link_to sponsor.name, sponsor.website
+    #sponsors
+      .small-12.column
+        %h3 Sponsors
+        %ul.row.no-bullet
+          - @workshop.sponsors.each do |sponsor|
+            %li.small-4.columns
+              = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
+              %p
+                = link_to sponsor.name, sponsor.website
 
 .stripe.reverse
   = render partial: 'members/organisers_grid', locals: { members: @workshop.organisers, show_info: false }

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -12,8 +12,7 @@
         #workshop-time.time
           %i.material-icons
             access_time
-          = @workshop.time
-          = @workshop.ends_at.present? ? "- " +  l(@workshop.ends_at, format: :time) : ""
+          = @workshop.start_and_end_time
       - if @workshop.date_and_time.past?
         %label.label.warning This event has already taken place.
   %section#banner

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -24,7 +24,7 @@
           = sanitize(@workshop.description)
 
         - unless current_user and current_user.banned?
-          = render 'workshop_actions'
+          = render 'actions'
 
 .stripe.reverse
   .row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,12 +88,18 @@ en:
       title: Virtual workshop for %{chapter} - %{date}
       invitation:
         shared_intro_3_html: 'PS: If you have any questions about the workshop or will not be able to attend on short notice please send us an email at %{email_link} as that will make pairing everyone up easier for us.'
+        info:
+          title: How to join
+          line_1_html: 'Sign up to the codebar Slack %{slack_link}'
+          line_2_html: 'Join the %{channel} on Slack'
     invitation:
       title: Workshop invitation - %{date}
+      info: Information about the workshop
+      cant_make_it_note: "If you can't make it or plan to arrive late please let us know by sending an email to %{email}"
       student_intro_1: 'In our workshops, you will get to go through any of our available tutorials, ask for programming advice or get help on your own projects.'
       student_intro_2: 'In case you are unable to attend after you RSVP, please make sure you come back and update your attendance. We have limited space and do a coaches request depending on the number of attending students.'
       student_intro_3_html: 'Please make sure you <b>bring your laptop</b> with you.'
-      student_intro_4_html: 'PS: There will also be food at the workshop. We always make an effort to have vegetarian, vegan and gluten-free options available. If you have any other dietary requirements, send us an email at %{email_link}.'
+      shared_intro_4_html: 'PS: There will also be food at the workshop. We always make an effort to have vegetarian, vegan and gluten-free options available. If you have any other dietary requirements, send us an email at %{email_link}.'
   meeting:
     title: "%{name} - %{date}"
   messages:
@@ -580,3 +586,5 @@ en:
         name: 'First name'
         newsletter: 'If you do not want to receive the codebar newsletter uncheck this box'
         pronouns: 'What pronouns do you use?'
+  social_media_links:
+    slack_html: https://slack.codebar.io

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,8 +86,14 @@ en:
     title: Workshop at %{host} - %{date}
     virtual:
       title: Virtual workshop for %{chapter} - %{date}
+      invitation:
+        shared_intro_3_html: 'PS: If you have any questions about the workshop or will not be able to attend on short notice please send us an email at %{email_link} as that will make pairing everyone up easier for us.'
     invitation:
       title: Workshop invitation - %{date}
+      student_intro_1: 'In our workshops, you will get to go through any of our available tutorials, ask for programming advice or get help on your own projects.'
+      student_intro_2: 'In case you are unable to attend after you RSVP, please make sure you come back and update your attendance. We have limited space and do a coaches request depending on the number of attending students.'
+      student_intro_3_html: 'Please make sure you <b>bring your laptop</b> with you.'
+      student_intro_4_html: 'PS: There will also be food at the workshop. We always make an effort to have vegetarian, vegan and gluten-free options available. If you have any other dietary requirements, send us an email at %{email_link}.'
   meeting:
     title: "%{name} - %{date}"
   messages:
@@ -168,7 +174,7 @@ en:
     no_spaces_available: 'There are no available spots left for this workshop but you can always join the waiting list.'
     already_attending: 'You are attending this event'
     on_waiting_list: You are on the waiting list.
-    already_taken_place: This event has already taken place.
+    already_taken_place: This workshop has already taken place.
     virtual:
       title: 'Virtual workshop for %{chapter}'
       lead: 'Participate in our workshops to learn programming in a supportive and collaborative online environment at your own pace, or share your knowledge and coach our students.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,7 @@ en:
       stubling: "Let them stumble. We learn by making mistakes, getting frustrated, and working through problem in our own way. Be supportive, but let them explore."
       suggestions: "Do you have something to suggest? Make a <a href='https://github.com/codebar/planner'>pull request</a> or <a href='https://github.com/codebar/planner/issues/new'>create an issue</a>"
   workshops:
+    title: Workshop at %{host}
     already_wish_to_attend: 'You have already RSVPd or joined the waitlist for this workshop.'
     lead: "Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students."
     not_open_for_rsvp: 'This workshop is not yet open for RSVP.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,7 @@ en:
   workshops:
     already_wish_to_attend: 'You have already RSVPd or joined the waitlist for this workshop.'
     lead: "Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students."
+    not_open_for_rsvp: 'This workshop is not yet open for RSVP.'
     registration_not_open: 'This workshop is not open for registrations'
   events:
     title: "Events"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -521,6 +521,9 @@ en:
         already_on_list: "%{name} is already on the list!"
         rsvp_error: "Something went wrong, %{name} has not been added."
         update_rsvp: 'Updated attendance of %{name}'
+      workshop:
+        created: 'Workshop successfully created'
+        no_host: 'Before you can proceed you must select a host'
   simple_form:
     placeholders:
       member:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,11 @@ en:
     lead: "Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students."
     not_open_for_rsvp: 'This workshop is not yet open for RSVP.'
     registration_not_open: 'This workshop is not open for registrations'
+    sign_up_to_be_invited: 'Sign up to be invited to future events.'
+    no_spaces_available: 'There are no available spots left for this workshop but you can always join the waiting list.'
+    already_attending: 'You are attending this event'
+    on_waiting_list: You are on the waiting list.
+    already_taken_place: This event has already taken place.
   events:
     title: "Events"
     past: "Past"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,8 @@ en:
         subject: "Reminder: you're on the codebar waiting list (%{date_time})"
   workshop:
     title: Workshop at %{host} - %{date}
+    virtual:
+      title: Virtual workshop for %{chapter} - %{date}
     invitation:
       title: Workshop invitation - %{date}
   meeting:
@@ -166,6 +168,10 @@ en:
     already_attending: 'You are attending this event'
     on_waiting_list: You are on the waiting list.
     already_taken_place: This event has already taken place.
+    virtual:
+      title: 'Virtual workshop for %{chapter}'
+      lead: 'Participate in our workshops to learn programming in a supportive and collaborative online environment at your own pace, or share your knowledge and coach our students.'
+      intro: 'Our virtual workshops take place online. Our aim is to help you get started with programming by pairing you with a coach that will be able to remotely assist and guide you through what you want to learn. Once you sign up we will email you more details about how to join the workshop and tools that we reccomend to make the process easier for you. In the meantime if you have any questions, do not hesitate to send an email to %{chapter_email}.'
   events:
     title: "Events"
     past: "Past"

--- a/db/migrate/20200311233721_add_virtual_to_workshop.rb
+++ b/db/migrate/20200311233721_add_virtual_to_workshop.rb
@@ -1,0 +1,5 @@
+class AddVirtualToWorkshop < ActiveRecord::Migration
+  def change
+    add_column :workshops, :virtual, :boolean, default: false
+  end
+end

--- a/db/migrate/20200312172212_add_student_and_coach_spaces_to_workshop.rb
+++ b/db/migrate/20200312172212_add_student_and_coach_spaces_to_workshop.rb
@@ -1,0 +1,6 @@
+class AddStudentAndCoachSpacesToWorkshop < ActiveRecord::Migration
+  def change
+    add_column :workshops, :student_spaces, :integer, default: 0
+    add_column :workshops, :coach_spaces, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200124124311) do
-ActiveRecord::Schema.define(version: 20200311233721) do
+ActiveRecord::Schema.define(version: 20200312172212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -564,6 +563,8 @@ ActiveRecord::Schema.define(version: 20200311233721) do
     t.datetime "rsvp_opens_at"
     t.datetime "ends_at"
     t.boolean  "virtual",        default: false
+    t.integer  "student_spaces", default: 0
+    t.integer  "coach_spaces",   default: 0
   end
 
   add_index "workshops", ["chapter_id"], name: "index_workshops_on_chapter_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20200124124311) do
+ActiveRecord::Schema.define(version: 20200311233721) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -562,6 +563,7 @@ ActiveRecord::Schema.define(version: 20200124124311) do
     t.datetime "rsvp_closes_at"
     t.datetime "rsvp_opens_at"
     t.datetime "ends_at"
+    t.boolean  "virtual",        default: false
   end
 
   add_index "workshops", ["chapter_id"], name: "index_workshops_on_chapter_id", using: :btree

--- a/spec/fabricators/workshop_fabricator.rb
+++ b/spec/fabricators/workshop_fabricator.rb
@@ -16,6 +16,8 @@ Fabricator(:virtual_workshop, class_name: :workshop) do
   description Faker::Lorem.sentence
   chapter
   virtual true
+  student_spaces 10
+  coach_spaces 10
   after_build do |workshop|
     Fabricate(:workshop_sponsor, workshop: workshop, sponsor: Fabricate(:sponsor), host: false)
   end

--- a/spec/fabricators/workshop_fabricator.rb
+++ b/spec/fabricators/workshop_fabricator.rb
@@ -9,6 +9,18 @@ Fabricator(:workshop) do
   end
 end
 
+Fabricator(:virtual_workshop, class_name: :workshop) do
+  date_and_time Time.zone.now + 2.days
+  ends_at Time.zone.now + 2.days + 2.hours
+  title Faker::Lorem.sentence
+  description Faker::Lorem.sentence
+  chapter
+  virtual true
+  after_build do |workshop|
+    Fabricate(:workshop_sponsor, workshop: workshop, sponsor: Fabricate(:sponsor), host: false)
+  end
+end
+
 Fabricator(:workshop_no_sponsor, class_name: :workshop) do
   date_and_time Time.zone.now + 2.days
   ends_at Time.zone.now + 2.days + 2.hours

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Accepting a workshop invitation', type: :feature do
 
     it_behaves_like 'invitation route'
 
-    context 'edit invitation' do
+    context 'amend invitation details' do
       scenario 'logged in user with accepted invitation can edit the note' do
         tutorial = Tutorial.create(title: 'Lesson 1 - Introducing HTML')
         invitation.update_attribute(:attending, true)

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.feature 'a member can', type: :feature do
+RSpec.feature 'Accepting a workshop invitation', type: :feature do
   context '#workshop' do
     let(:member) { Fabricate(:member) }
     let(:invitation) { Fabricate(:workshop_invitation, member: member) }
@@ -35,57 +35,6 @@ RSpec.feature 'a member can', type: :feature do
         click_on 'Update note'
 
         expect(page).to have_content('You must select a note')
-      end
-    end
-  end
-
-  context '#course' do
-    let(:invitation) { Fabricate(:course_invitation) }
-    let(:accepting_invitation_path) { accept_course_invitation_path(invitation) }
-    let(:rejecting_invitation_path) { reject_course_invitation_path(invitation) }
-
-    let(:set_no_available_slots) { invitation.course.update_attribute(:seats, 0) }
-
-    context 'accept an invitation' do
-      scenario 'when there are available spots' do
-        visit accepting_invitation_path
-
-        expect(current_url).to eq(root_url)
-        expect(page).to have_content("Thanks for getting back to us #{invitation.member.name}.")
-      end
-
-      scenario 'when they have already confirmed their attendance' do
-        invitation.update_attribute(:attending, true)
-        visit accepting_invitation_path
-
-        expect(current_url).to eq(root_url)
-        expect(page).to have_content('You have already confirmed you attendance!')
-      end
-
-      scenario 'when there are no available spots' do
-        set_no_available_slots
-        visit accepting_invitation_path
-
-        expect(current_url).to eq(root_url)
-        expect(page).to have_content('Unfortunately there are no more spaces left :(.')
-      end
-    end
-
-    context 'reject an invitation' do
-      scenario 'when they are successful' do
-        invitation.update_attribute(:attending, true)
-        visit rejecting_invitation_path
-
-        expect(current_url).to eq(root_url)
-        expect(page).to have_content(I18n.t('messages.rejected_invitation', name: invitation.member.name))
-      end
-
-      scenario 'when already confirmed' do
-        invitation.update_attribute(:attending, false)
-        visit rejecting_invitation_path
-
-        expect(current_url).to eq(root_url)
-        expect(page).to have_content(I18n.t('messages.not_attending_already'))
       end
     end
   end

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.feature 'Managing workshops', type: :feature do
+RSpec.feature 'An admin managing workshops', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:chapter) { Fabricate(:chapter) }
   let!(:sponsor) { Fabricate(:sponsor) }
@@ -10,113 +10,135 @@ RSpec.feature 'Managing workshops', type: :feature do
     member.add_role(:organiser, Chapter)
   end
 
-  scenario 'viewing list of all chapter workshops' do
-    workshops = Fabricate.times(5, :workshop, chapter: chapter)
-    visit admin_chapter_workshops_path(chapter)
+  context '#views' do
+    scenario 'list of all chapter workshops' do
+      workshops = Fabricate.times(5, :workshop, chapter: chapter)
+      visit admin_chapter_workshops_path(chapter)
 
-    workshops.each do |workshop|
-      expect(page).to have_content(humanize_date(workshop.date_and_time, with_time: true, with_year: true))
+      workshops.each do |workshop|
+        expect(page).to have_content(humanize_date(workshop.date_and_time, with_time: true, with_year: true))
+      end
     end
   end
 
-  context 'creating a new workshop' do
-    scenario 'successfully' do
-      visit new_admin_workshop_path
+  context '#creation' do
+    context 'creating a workshop' do
+      scenario 'requires a host and a start and end datetime to be set' do
+        visit new_admin_workshop_path
 
-      select chapter.name
-      fill_in 'Date', with: Date.current
-      fill_in 'Begins at', with: '11:30'
+        select chapter.name
+        fill_in 'Date', with: Date.current
+        fill_in 'Begins at', with: '11:30'
+        fill_in 'Ends at', with: '12:45'
 
-      click_on 'Save'
+        within '#host' do
+          select sponsor.name
+        end
 
-      expect(page).to have_content('The workshop has been created')
-      expect(page).to have_content 'Invite'
+        click_on 'Save'
+
+        expect(page).to have_content('Workshop successfully created')
+        expect(page).to have_content '11:30 - 12:45'
+        expect(page).to have_content 'Invite'
+      end
+
+      scenario 'must have a chapter set' do
+        visit new_admin_workshop_path
+
+        within '#host' do
+          select sponsor.name
+        end
+
+        fill_in 'Date', with: Date.current
+        fill_in 'Begins at', with: '11:30'
+
+        click_on 'Save'
+
+        expect(page).to have_content('Chapter can\'t be blank')
+      end
+
+      scenario 'must have a host set' do
+        visit new_admin_workshop_path
+
+        select chapter.name
+        fill_in 'Date', with: Date.current
+        fill_in 'Begins at', with: '11:30'
+
+        click_on 'Save'
+
+        expect(page).to have_content('Before you can proceed you must select a host')
+      end
+
+      scenario 'can have sponsors assigned' do
+        workshop = Fabricate(:workshop_no_sponsor)
+        visit edit_admin_workshop_path(workshop)
+
+        select sponsor.name, from: 'workshop_sponsor_ids'
+
+        click_on 'Save'
+
+        within '#sponsors' do
+          expect(page).to have_content sponsor.name
+        end
+      end
     end
 
-    scenario 'with ends_at' do
-      visit new_admin_workshop_path
+    context 'creating a virtual workshop' do
+      scenario 'does not require a host to be set' do
+        visit new_admin_workshop_path
 
-      select chapter.name
-      fill_in 'Date', with: Date.current
-      fill_in 'Begins at', with: '11:30'
-      fill_in 'Ends at', with: '12:45'
+        check 'Virtual'
 
-      click_on 'Save'
+        select chapter.name
+        fill_in 'Date', with: Date.current
+        fill_in 'Begins at', with: '11:30'
 
-      expect(page).to have_content('The workshop has been created')
-      expect(page).to have_content '11:30 - 12:45'
-    end
+        click_on 'Save'
 
-    scenario 'renders an error when no chapter has been selected' do
-      visit new_admin_workshop_path
-
-      fill_in 'Date', with: Date.current
-      fill_in 'Begins at', with: '11:30'
-
-      click_on 'Save'
-
-      expect(page).to have_content('Chapter can\'t be blank')
-    end
-  end
-
-  scenario 'assigning a host to a workshop' do
-    workshop = Fabricate(:workshop_no_sponsor)
-    visit edit_admin_workshop_path(workshop)
-
-    select sponsor.name, from: 'workshop_host'
-
-    click_on 'Save'
-
-    within '#host' do
-      expect(page).to have_content sponsor.name
-    end
-  end
-
-  scenario 'assigning a sponsor to a workshop' do
-    workshop = Fabricate(:workshop_no_sponsor)
-    visit edit_admin_workshop_path(workshop)
-
-    select sponsor.name, from: 'workshop_sponsor_ids'
-
-    click_on 'Save'
-
-    within '#sponsors' do
-      expect(page).to have_content sponsor.name
-    end
-  end
-
-  scenario 'sending invitations to workshop attendees' do
-    workshop = Fabricate(:workshop)
-    visit admin_workshop_send_invites_path(workshop)
-    click_on 'Students'
-
-    expect(page).to have_content('Invitations to students are being emailed out')
-  end
-
-  scenario 'rendering a text file with all the workshop attendee emails' do
-    workshop = Fabricate(:workshop)
-    attendees = Fabricate.times(4, :attending_workshop_invitation, workshop: workshop)
-    attendees_emails = attendees.map(&:member).map(&:email)
-    visit admin_workshop_attendees_emails_path(workshop, format: :text)
-
-    attendees_emails.each do |email|
-      expect(page).to have_content(email)
+        expect(page).to have_content('Workshop successfully created')
+        expect(page).to have_content 'Invite'
+      end
     end
   end
 
-  scenario 'rendering a list with the workshop attendee names' do
-    workshop = Fabricate(:workshop)
-    attendees = Fabricate.times(4, :attending_workshop_invitation, workshop: workshop)
-    visit admin_workshop_attendees_checklist_path(workshop, format: :text)
-    attendees.map(&:member).map(&:full_name).each do |name|
-      expect(page).to have_content(name)
+
+  context '#actions' do
+    scenario 'sending invitations to attendees' do
+      workshop = Fabricate(:workshop)
+      visit admin_workshop_send_invites_path(workshop)
+      click_on 'Students'
+
+      expect(page).to have_content('Invitations to students are being emailed out')
     end
-  end
 
-  scenario 'attempting to render a list with the workshop attendee names without a request text format' do
-    workshop = Fabricate(:workshop)
-    visit admin_workshop_attendees_checklist_path(workshop)
+    scenario 'viewing a text file with all attendee emails' do
+      workshop = Fabricate(:workshop)
+      attendees = Fabricate.times(4, :attending_workshop_invitation, workshop: workshop)
+      attendees_emails = attendees.map(&:member).map(&:email)
+      visit admin_workshop_attendees_emails_path(workshop, format: :text)
 
-    expect(page.current_path).to eq(admin_workshop_path(workshop))
+      attendees_emails.each do |email|
+        expect(page).to have_content(email)
+      end
+    end
+
+    context 'attendee names list' do
+      scenario 'viewing a text file with all names' do
+        workshop = Fabricate(:workshop)
+        attendees = Fabricate.times(4, :attending_workshop_invitation, workshop: workshop)
+        visit admin_workshop_attendees_checklist_path(workshop, format: :text)
+        attendees.map(&:member).map(&:full_name).each do |name|
+          expect(page).to have_content(name)
+        end
+      end
+
+      scenario 'viewing an error message when the requested list format is invalid' do
+        workshop = Fabricate(:workshop)
+        visit admin_workshop_attendees_checklist_path(workshop)
+
+        expect(page.current_path).to eq(admin_workshop_path(workshop))
+        expect(page).to have_content('The requested format is invalid: text/html')
+      end
+    end
   end
 end

--- a/spec/features/managing_course_invitation_spec.rb
+++ b/spec/features/managing_course_invitation_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.feature 'Managing a course invitation', type: :feature do
+  let(:invitation) { Fabricate(:course_invitation) }
+  let(:accepting_invitation_path) { accept_course_invitation_path(invitation) }
+  let(:rejecting_invitation_path) { reject_course_invitation_path(invitation) }
+
+  let(:set_no_available_slots) { invitation.course.update_attribute(:seats, 0) }
+
+  context 'accept an invitation' do
+    scenario 'when there are available spots' do
+      visit accepting_invitation_path
+
+      expect(current_url).to eq(root_url)
+      expect(page).to have_content("Thanks for getting back to us #{invitation.member.name}.")
+    end
+
+    scenario 'when they have already confirmed their attendance' do
+      invitation.update_attribute(:attending, true)
+      visit accepting_invitation_path
+
+      expect(current_url).to eq(root_url)
+      expect(page).to have_content('You have already confirmed you attendance!')
+    end
+
+    scenario 'when there are no available spots' do
+      set_no_available_slots
+      visit accepting_invitation_path
+
+      expect(current_url).to eq(root_url)
+      expect(page).to have_content('Unfortunately there are no more spaces left :(.')
+    end
+  end
+
+  context 'reject an invitation' do
+    scenario 'when they are successful' do
+      invitation.update_attribute(:attending, true)
+      visit rejecting_invitation_path
+
+      expect(current_url).to eq(root_url)
+      expect(page).to have_content(I18n.t('messages.rejected_invitation', name: invitation.member.name))
+    end
+
+    scenario 'when already confirmed' do
+      invitation.update_attribute(:attending, false)
+      visit rejecting_invitation_path
+
+      expect(current_url).to eq(root_url)
+      expect(page).to have_content(I18n.t('messages.not_attending_already'))
+    end
+  end
+end

--- a/spec/features/managining_workshop_attendance_spec.rb
+++ b/spec/features/managining_workshop_attendance_spec.rb
@@ -1,183 +1,21 @@
 require 'spec_helper'
 RSpec.feature 'Managing workshop attendance', type: :feature do
-  let(:workshop) { Fabricate(:workshop) }
-  let(:workshop_auto_rsvp_in_past) { Fabricate(:workshop_auto_rsvp_in_past) }
-  let(:workshop_auto_rsvp_in_future) { Fabricate(:workshop_auto_rsvp_in_future) }
   let(:coach) { Fabricate(:coach) }
   let(:student) { Fabricate(:student) }
 
-  context 'a logged in member' do
-    context '#upcoming workshop' do
-      context 'via the workshop page' do
-        context 'with only student subscriptions' do
-          before do
-            login(student)
-            visit workshop_path(workshop)
-          end
+  context '#workshop' do
+    let(:workshop) { Fabricate(:workshop) }
+    let(:workshop_auto_rsvp_in_past) { Fabricate(:workshop_auto_rsvp_in_past) }
+    let(:workshop_auto_rsvp_in_future) { Fabricate(:workshop_auto_rsvp_in_future) }
 
-          it 'can only RSVP as a student' do
-            click_on 'Attend as a student'
-            click_on 'Attend'
+    include_examples 'managing workshop attendance'
+  end
 
-            expect(page).to have_content('See you at the workshop')
+  context '#virtual workshop' do
+    let(:workshop) { Fabricate(:virtual_workshop) }
+    let(:workshop_auto_rsvp_in_past) { Fabricate(:workshop_auto_rsvp_in_past) }
+    let(:workshop_auto_rsvp_in_future) { Fabricate(:workshop_auto_rsvp_in_future) }
 
-            visit workshop_path(workshop)
-            expect(page).to have_button('Manage your invitation')
-          end
-
-          it 'cannot RSVP as a coach' do
-            expect(page).not_to have_content('Attend as a coach')
-          end
-        end
-
-        context 'with only coach subscriptions' do
-          before do
-            login(coach)
-            visit workshop_path(workshop)
-          end
-
-          it 'can only RSVP as a coach' do
-            click_on 'Attend as a coach'
-            click_on 'Attend'
-
-            expect(page).to have_content('See you at the workshop')
-
-            visit workshop_path(workshop)
-            expect(page).to have_button('Manage your invitation')
-          end
-
-          it 'cannot RSVP as a student' do
-            expect(page).not_to have_content('Attend as a student')
-          end
-        end
-
-        context 'with both coach and student subscriptions' do
-          before do
-            kara = Fabricate(:student)
-            coaches = Fabricate(:coaches)
-            kara.groups << coaches
-            login(kara)
-            visit workshop_path(workshop)
-          end
-
-          it 'can get to the RSVP as a student page' do
-            click_on 'Attend as a student'
-            click_on 'Attend'
-
-            expect(page).to have_content('See you at the workshop')
-
-            visit workshop_path(workshop)
-            expect(page).to have_button('Manage your invitation')
-          end
-
-          it 'can get to the RSVP as a coach page' do
-            click_on 'Attend as a coach'
-            click_on 'Attend'
-
-            expect(page).to have_content('See you at the workshop')
-
-            visit workshop_path(workshop)
-            expect(page).to have_button('Manage your invitation')
-          end
-        end
-
-        context 'who has already RSVPed' do
-          let(:student) { Fabricate(:student) }
-
-          before do
-            coaches = Fabricate(:coaches)
-            student.groups << coaches
-            login(student)
-          end
-
-          it 'can get back to their invitation page' do
-            visit workshop_path(workshop)
-
-            click_on 'Attend as a coach'
-            click_on 'Attend'
-
-            visit workshop_path(workshop)
-
-            click_on 'Manage your invitation'
-            expect(page).to have_content("Hi #{student.name}")
-            expect(page).to have_content('You should also go through our coaching guide')
-          end
-        end
-
-        context 'with no subscriptions' do
-          before do
-            no_subs = Fabricate(:member)
-            login(no_subs)
-            visit workshop_path(workshop)
-          end
-
-          it 'will be prompted to manage their subscriptions' do
-            expect(page).to have_content('Please tell us whether you want to attend as a student or coach.')
-
-            click_link 'Please tell us whether you want to attend as a student or coach.'
-            expect(page).to have_current_path(subscriptions_path)
-          end
-
-          it 'cannot access RSVP as a student or coach' do
-            expect(page).not_to have_content('Attend as a student')
-            expect(page).not_to have_content('Attend as a coach')
-          end
-        end
-      end
-
-      context 'managing invitations' do
-        before do
-          login(coach)
-          visit workshop_path(workshop)
-        end
-
-        context 'when auto RSVP open time is past, invitable turned off' do
-          it 'can access RSVP as a coach' do
-            visit workshop_path(workshop_auto_rsvp_in_past)
-
-            click_on 'Attend as a coach'
-            click_on 'Attend'
-
-            expect(page).to have_content('See you at the workshop')
-          end
-
-          after do
-            visit workshop_path(workshop_auto_rsvp_in_past)
-            expect(page).to have_button('Manage your invitation')
-          end
-        end
-
-        context 'when auto RSVP open time is future, invitable turned off' do
-          it 'cannot access RSVP as a student or coach' do
-            visit workshop_path(workshop_auto_rsvp_in_future)
-
-            expect(page).to have_content('This workshop is not yet open for RSVP.')
-          end
-        end
-
-        context 'when invitations have been sent out' do
-          let(:member) { Fabricate(:member) }
-          let!(:invitation) { Fabricate(:attending_workshop_invitation, member: member, workshop: workshop) }
-
-          it 'can manage details if they are already attending' do
-            login(member)
-            visit workshop_path(workshop)
-
-            expect(page).to have_button('Manage your invitation')
-            expect(page).not_to have_link('Attend as a student')
-            expect(page).not_to have_link('Attend as a coach')
-          end
-        end
-      end
-    end
-
-    context '#past workshop' do
-      let(:workshop) { Fabricate(:workshop, date_and_time: 2.weeks.ago) }
-
-      scenario 'cannot interact with a past event' do
-        visit workshop_path(workshop)
-        expect(page).to have_content('has already taken place')
-      end
-    end
+    include_examples 'managing workshop attendance'
   end
 end

--- a/spec/features/viewing_a_workshop_invitation_spec.rb
+++ b/spec/features/viewing_a_workshop_invitation_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+RSpec.feature 'Viewing a workshop invitation', type: :feature, wip: true do
+  let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop) }
+
+  before do
+    visit invitation_path(invitation)
+  end
+
+  context 'physical workshop' do
+    let(:workshop) { Fabricate(:workshop) }
+
+    scenario 'workshop and page title' do
+      expect(page).to have_title("Workshop invitation - #{humanize_date(workshop.date_and_time)}")
+      expect(page).to have_content("Workshop at #{workshop.host.name}")
+    end
+
+    context '#introduction' do
+      context 'student' do
+        scenario 'displays information for a physical workshop' do
+          expect(page).to have_content('Please make sure you bring your laptop')
+        end
+      end
+
+      context 'coach' do
+        scenario 'displays information for a physical workshop' do
+          expect(page).to have_content('PS: There will also be food at the workshop.')
+        end
+      end
+    end
+
+    scenario 'venue name and address' do
+      within '#venue' do
+        expect(page).to have_content(workshop.host.name)
+
+        within '#address' do
+          expect(page).to have_content(workshop.host.address.street)
+          expect(page).to have_content(workshop.host.address.city)
+        end
+      end
+    end
+
+    context '#description' do
+      it 'contains details about the workshop' do
+        within '#info' do
+          expect(page).to have_content('Information about the workshop')
+          expect(page).to_not have_content('How to join')
+        end
+      end
+    end
+
+    include_examples "viewing workshop details"
+  end
+
+  context 'virtual workshop' do
+    let(:workshop) { Fabricate(:virtual_workshop) }
+
+    scenario 'workshop and page title' do
+      expect(page).to have_title("Workshop invitation - #{humanize_date(workshop.date_and_time)}")
+      expect(page).to have_content("Virtual workshop for #{workshop.chapter.name}")
+    end
+
+    context '#introduction' do
+      context 'student' do
+        scenario 'does not display information about the physical workshop' do
+          expect(page).to_not have_content('Please make sure you bring your laptop')
+        end
+      end
+
+      context 'coach' do
+        scenario 'does not displays information about the physical workshop' do
+          expect(page).to_not have_content('PS: There will also be food at the workshop.')
+        end
+      end
+    end
+
+    context '#description' do
+      it 'contains details about the workshop' do
+        within '#info' do
+          expect(page).to have_content('Information about the workshop')
+        end
+      end
+
+      context 'when RSVPed' do
+        let(:invitation) { Fabricate(:attending_workshop_invitation, workshop: workshop) }
+
+        it 'contains details about how to join the workshop' do
+          expect(page).to have_content('How to join')
+        end
+      end
+    end
+
+    include_examples "viewing workshop details"
+
+  end
+end

--- a/spec/features/viewing_a_workshop_spec.rb
+++ b/spec/features/viewing_a_workshop_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+RSpec.feature 'Viewing a workshop page', type: :feature do
+  context 'visitor' do
+    before(:each) do
+      visit workshop_path(workshop)
+    end
+
+    let(:workshop) { Fabricate(:workshop) }
+
+    scenario 'can view a workshop' do
+      expect(page).to be
+    end
+
+    scenario 'can view the page title' do
+      expect(page).to have_title("Workshop at #{workshop.host.name} - #{humanize_date(workshop.date_and_time)}")
+    end
+
+    scenario 'can sign up or sign in' do
+      expect(page).to have_content('Sign up')
+      expect(page).to have_content('Log in')
+    end
+  end
+end

--- a/spec/features/viewing_a_workshop_spec.rb
+++ b/spec/features/viewing_a_workshop_spec.rb
@@ -51,5 +51,53 @@ RSpec.feature 'Viewing a workshop page', type: :feature do
         end
       end
     end
+
+    context 'virtual workshop' do
+      let(:workshop) { Fabricate(:virtual_workshop) }
+
+      describe '#details' do
+        scenario 'workshop and page title' do
+          expect(page)
+            .to have_title("Virtual workshop for #{workshop.chapter.name} - #{humanize_date(workshop.date_and_time)}")
+          expect(page).to have_content("Virtual workshop for #{workshop.chapter.name}")
+        end
+
+        scenario 'workshop info' do
+          within '#banner' do
+            expect(page).to have_content('Participate in our workshops')
+            expect(page).to have_content('Our virtual workshops take place online')
+
+            within '.lead.description' do
+              expect(page).to have_content(workshop.description)
+            end
+          end
+        end
+
+        scenario 'sponsors' do
+          within '#sponsors' do
+            workshop.sponsors.each do |sponsor|
+              expect(page).to have_content(sponsor.name)
+            end
+          end
+        end
+
+        scenario 'organisers' do
+          within '#organisers' do
+            expect(page).to have_content('Organisers')
+
+            workshop.organisers.each do |organiser|
+              expect(page).to have_content(organiser.full_name)
+            end
+          end
+        end
+      end
+
+      describe '#actions' do
+        scenario 'signing up or signing in' do
+          expect(page).to have_content('Sign up')
+          expect(page).to have_content('Log in')
+        end
+      end
+    end
   end
 end

--- a/spec/features/viewing_a_workshop_spec.rb
+++ b/spec/features/viewing_a_workshop_spec.rb
@@ -1,23 +1,43 @@
 require 'spec_helper'
 RSpec.feature 'Viewing a workshop page', type: :feature do
   context 'visitor' do
-    before(:each) do
+    before do
       visit workshop_path(workshop)
     end
 
-    let(:workshop) { Fabricate(:workshop) }
+    context 'workshop' do
+      let(:workshop) { Fabricate(:workshop) }
 
-    scenario 'can view a workshop' do
-      expect(page).to be
-    end
+      describe '#details' do
+        scenario 'workshop and page title' do
+          expect(page).to have_title("Workshop at #{workshop.host.name} - #{humanize_date(workshop.date_and_time)}")
+          expect(page).to have_content("Workshop at #{workshop.host.name}")
+        end
 
-    scenario 'can view the page title' do
-      expect(page).to have_title("Workshop at #{workshop.host.name} - #{humanize_date(workshop.date_and_time)}")
-    end
+        scenario 'venue name and address' do
+          within '#venue' do
+            expect(page).to have_content(workshop.host.name)
 
-    scenario 'can sign up or sign in' do
-      expect(page).to have_content('Sign up')
-      expect(page).to have_content('Log in')
+            within '#address' do
+              expect(page).to have_content(workshop.host.address.street)
+              expect(page).to have_content(workshop.host.address.city)
+            end
+          end
+        end
+
+        scenario 'sponsor name' do
+          within '#sponsors' do
+            expect(page).to have_content(workshop.host.name)
+          end
+        end
+      end
+
+      describe '#actions' do
+        scenario 'signing up or signing in' do
+          expect(page).to have_content('Sign up')
+          expect(page).to have_content('Log in')
+        end
+      end
     end
   end
 end

--- a/spec/features/viewing_a_workshop_spec.rb
+++ b/spec/features/viewing_a_workshop_spec.rb
@@ -25,9 +25,21 @@ RSpec.feature 'Viewing a workshop page', type: :feature do
           end
         end
 
-        scenario 'sponsor name' do
+        scenario 'sponsors' do
           within '#sponsors' do
-            expect(page).to have_content(workshop.host.name)
+            workshop.sponsors.each do |sponsor|
+              expect(page).to have_content(sponsor.name)
+            end
+          end
+        end
+
+        scenario 'organisers' do
+          within '#organisers' do
+            expect(page).to have_content('Organisers')
+
+            workshop.organisers.each do |organiser|
+              expect(page).to have_content(organiser.full_name)
+            end
           end
         end
       end

--- a/spec/features/viewing_a_workshop_spec.rb
+++ b/spec/features/viewing_a_workshop_spec.rb
@@ -25,30 +25,11 @@ RSpec.feature 'Viewing a workshop page', type: :feature do
           end
         end
 
-        scenario 'sponsors' do
-          within '#sponsors' do
-            workshop.sponsors.each do |sponsor|
-              expect(page).to have_content(sponsor.name)
-            end
-          end
-        end
-
-        scenario 'organisers' do
-          within '#organisers' do
-            expect(page).to have_content('Organisers')
-
-            workshop.organisers.each do |organiser|
-              expect(page).to have_content(organiser.full_name)
-            end
-          end
-        end
+        include_examples "viewing workshop details"
       end
 
       describe '#actions' do
-        scenario 'signing up or signing in' do
-          expect(page).to have_content('Sign up')
-          expect(page).to have_content('Log in')
-        end
+        include_examples "viewing workshop actions"
       end
     end
 
@@ -73,30 +54,11 @@ RSpec.feature 'Viewing a workshop page', type: :feature do
           end
         end
 
-        scenario 'sponsors' do
-          within '#sponsors' do
-            workshop.sponsors.each do |sponsor|
-              expect(page).to have_content(sponsor.name)
-            end
-          end
-        end
-
-        scenario 'organisers' do
-          within '#organisers' do
-            expect(page).to have_content('Organisers')
-
-            workshop.organisers.each do |organiser|
-              expect(page).to have_content(organiser.full_name)
-            end
-          end
-        end
+        include_examples "viewing workshop details"
       end
 
       describe '#actions' do
-        scenario 'signing up or signing in' do
-          expect(page).to have_content('Sign up')
-          expect(page).to have_content('Log in')
-        end
+        include_examples "viewing workshop actions"
       end
     end
   end

--- a/spec/mailers/workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/workshop_invitation_mailer_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-RSpec.describe WorkshopInvitationMailer, type: :mailer  do
+RSpec.describe WorkshopInvitationMailer, type: :mailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:workshop) { Fabricate(:workshop, title: 'HTML & CSS') }
   let(:member) { Fabricate(:member) }
   let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: member) }
   let(:sponsor) { Fabricate(:sponsor) }
 
-  it "#attending" do
+  it '#attending' do
     email_subject = "Attendance Confirmation for #{humanize_date(workshop.date_and_time, with_time: true)}"
 
     WorkshopInvitationMailer.attending(workshop, member, invitation).deliver_now
@@ -25,9 +25,20 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer  do
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 
-  it "#change_of_details" do
+  it '#attending_virtual' do
+    email_subject = "Attendance Confirmation: Virtual workshop for #{workshop.chapter.name} " \
+                    "- #{humanize_date(workshop.date_and_time)}"
+
+    WorkshopInvitationMailer.attending_virtual(workshop, member, invitation).deliver_now
+
+    expect(email.subject).to eq(email_subject)
+    expect(email.body.encoded).to match(workshop.chapter.email)
+  end
+
+  it '#change_of_details' do
     title = 'Change of details'
-    email_subject = "#{title}: #{workshop.title} by codebar - #{humanize_date(workshop.date_and_time, with_time: true)}"
+    email_subject = "#{title}: #{workshop.title} by codebar - " \
+                    "#{humanize_date(workshop.date_and_time, with_time: true)}"
 
     WorkshopInvitationMailer.change_of_details(workshop, sponsor, member, invitation).deliver_now
 
@@ -62,7 +73,8 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer  do
   end
 
   it '#waitlist_reminder' do
-    email_subject = "Reminder: you're on the codebar waiting list (#{humanize_date(workshop.date_and_time, with_time: true)})"
+    email_subject = "Reminder: you're on the codebar waiting list " \
+                    "(#{humanize_date(workshop.date_and_time, with_time: true)})"
 
     WorkshopInvitationMailer.waiting_list_reminder(workshop, member, invitation).deliver_now
 

--- a/spec/presenters/virtual_workshop_presenter_spec.rb
+++ b/spec/presenters/virtual_workshop_presenter_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 RSpec.describe VirtualWorkshopPresenter do
   def double_workshop(attending_coaches:, attending_students:)
     double(:workshop, coach_spaces: 3, student_spaces: 5, chapter: chapter,
-           attending_coaches: double(:attending_coaches, length: attending_coaches),
-           attending_students: double(:attending_students, length: attending_students))
+                      attending_coaches: double(:attending_coaches, length: attending_coaches),
+                      attending_students: double(:attending_students, length: attending_students))
   end
 
   let(:chapter) { Fabricate(:chapter) }
@@ -56,6 +56,19 @@ RSpec.describe VirtualWorkshopPresenter do
       it 'it returns false' do
         expect(presenter.spaces?).to eq(false)
       end
+    end
+  end
+
+  context '#send_attending_email' do
+    it 'send an attending email to the invitation user' do
+      workshop_invitation_mailer = double(:workshop_invitation_mailed, deliver_now: true)
+      invitation = double(:invitation, member: double(:member))
+      expect(WorkshopInvitationMailer)
+        .to receive(:attending_virtual)
+        .with(workshop, invitation.member, invitation)
+        .and_return(workshop_invitation_mailer)
+
+      presenter.send_attending_email(invitation)
     end
   end
 end

--- a/spec/presenters/virtual_workshop_presenter_spec.rb
+++ b/spec/presenters/virtual_workshop_presenter_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe VirtualWorkshopPresenter do
+  def double_workshop(attending_coaches:, attending_students:)
+    double(:workshop, coach_spaces: 3, student_spaces: 5, chapter: chapter,
+           attending_coaches: double(:attending_coaches, length: attending_coaches),
+           attending_students: double(:attending_students, length: attending_students))
+  end
+
+  let(:chapter) { Fabricate(:chapter) }
+  let(:workshop) { double_workshop(attending_coaches: 3, attending_students: 4) }
+  let(:presenter) { VirtualWorkshopPresenter.new(workshop) }
+
+  context '#title' do
+    it 'returns the title of a virtual workshop' do
+      expect(presenter.title).to eq("Virtual workshop for #{chapter.name}")
+    end
+  end
+
+  context '#attending_and_available_student_spots' do
+    it 'returns the attending students count over the available workshop spots' do
+      expect(presenter.attending_and_available_student_spots).to eq('4/5')
+    end
+  end
+
+  context '#attending_and_available_coach_spots' do
+    it 'returns the attending coaches count over the available workshop spots' do
+      expect(presenter.attending_and_available_coach_spots).to eq('3/3')
+    end
+  end
+
+  context '#student_spaces?' do
+    it 'checks if there are any more available student spots' do
+      expect(presenter.student_spaces?).to eq(true)
+    end
+  end
+
+  context '#coach_spaces?' do
+    it 'checks if there are any more available coach spots' do
+      expect(presenter.coach_spaces?).to eq(false)
+    end
+  end
+
+  context '#spaces?' do
+    context 'when there are more available spots' do
+      let(:workshop) { double_workshop(attending_coaches: 2, attending_students: 5) }
+
+      it 'it returns true' do
+        expect(presenter.spaces?).to eq(true)
+      end
+    end
+
+    context 'when there are no more available spots' do
+      let(:workshop) { double_workshop(attending_coaches: 3, attending_students: 5) }
+
+      it 'it returns false' do
+        expect(presenter.spaces?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe WorkshopPresenter do
     end
   end
 
+  context '#address' do
+    it 'returns the decorated address of the workshop\'s venue' do
+      expect(presenter.address.to_html).to eq(AddressPresenter.new(host.address).to_html)
+    end
+  end
+
   context '#title' do
     it 'returns the title of a workshop' do
       expect(presenter.title).to eq("Workshop at #{host.name}")
@@ -126,6 +132,19 @@ RSpec.describe WorkshopPresenter do
       it 'it returns false' do
         expect(presenter.spaces?).to eq(false)
       end
+    end
+  end
+
+  context '#send_attending_email' do
+    it 'send an attending email to the invitation user' do
+      workshop_invitation_mailer = double(:workshop_invitation_mailed, deliver_now: true)
+      invitation = double(:invitation, member: double(:member))
+      expect(WorkshopInvitationMailer)
+        .to receive(:attending)
+        .with(workshop, invitation.member, invitation)
+        .and_return(workshop_invitation_mailer)
+
+      presenter.send_attending_email(invitation)
     end
   end
 end

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe WorkshopPresenter do
         expect(presenter.start_and_end_time).to eq(I18n.l(workshop.time, format: :time))
       end
 
-      it 'when a start and end_time are set it returns a formatted start and end_time' do
+      it 'when a start and an end_time are set it returns a formatted start and end_time' do
         workshop =  double(:workshop, time: Time.zone.now, ends_at: 1.hour.from_now)
         presenter = WorkshopPresenter.new(workshop)
 
@@ -79,5 +79,53 @@ RSpec.describe WorkshopPresenter do
     end
 
     expect(presenter.attendees_emails.split(', ')).to match_array(members.map(&:email))
+  end
+
+  context '#spaces?' do
+    let(:sponsor) { double(:sponsor, coach_spots: 3, seats: 5, chapter: chapter) }
+
+    def double_workshop(attending_coaches:, attending_students:, virtual:)
+      double(:workshop, coach_spaces: 3, student_spaces: 5, host: sponsor,
+                        attending_coaches: double(:attending_coaches, length: attending_coaches),
+                        attending_students: double(:attending_students, length: attending_students),
+                        virtual?: virtual)
+    end
+
+
+    context 'for a physical workshop' do
+      context 'when the host has more available spots' do
+        let(:workshop) { double_workshop(attending_coaches: 2, attending_students: 3, virtual: false) }
+
+        it 'it returns true' do
+          expect(presenter.spaces?).to eq(true)
+        end
+      end
+
+      context 'when the host has no more available spots' do
+        let(:workshop) { double_workshop(attending_coaches: 3, attending_students: 5, virtual: false) }
+
+        it 'it returns false' do
+          expect(presenter.spaces?).to eq(false)
+        end
+      end
+    end
+
+    context 'for a virtual workshop' do
+      context 'when there are more available spots' do
+        let(:workshop) { double_workshop(attending_coaches: 2, attending_students: 5, virtual: true) }
+
+        it 'it returns true' do
+          expect(presenter.spaces?).to eq(true)
+        end
+      end
+
+      context 'when there are no more available spots' do
+        let(:workshop) { double_workshop(attending_coaches: 3, attending_students: 5, virtual: true) }
+
+        it 'it returns true' do
+          expect(presenter.spaces?).to eq(false)
+        end
+      end
+    end
   end
 end

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -1,69 +1,72 @@
 require 'spec_helper'
 
 RSpec.describe WorkshopPresenter do
-  let(:invitations) do
-    [Fabricate(:student_workshop_invitation),
-     Fabricate(:student_workshop_invitation),
-     Fabricate(:coach_workshop_invitation),
-     Fabricate(:coach_workshop_invitation)]
-  end
   let(:chapter) { Fabricate(:chapter) }
-  let(:workshop_double) do
-    double(:workshop, time: Time.zone.now, ends_at: 1.hour.from_now,
-           attendances: invitations, host: Fabricate(:sponsor), chapter: chapter)
-  end
-  let(:workshop) { WorkshopPresenter.new(workshop_double) }
+  let(:workshop) { double(:workshop, host: Fabricate(:sponsor), chapter: chapter) }
+  let(:presenter) { WorkshopPresenter.new(workshop) }
 
   it '#venue' do
-    expect(workshop_double).to receive(:host)
+    expect(workshop).to receive(:host)
 
-    workshop.venue
+    presenter.venue
   end
 
   it '#organisers' do
-    expect(workshop_double).to receive(:permissions)
-    expect(workshop_double).to receive(:chapter).and_return(chapter)
+    expect(workshop).to receive(:permissions)
+    expect(workshop).to receive(:chapter).and_return(chapter)
 
-    workshop.organisers
+    presenter.organisers
   end
 
-  it '#time' do
-    start_time = workshop_double.time
-    expect(workshop.time).to eq(I18n.l(start_time, format: :time))
-  end
+  context 'time formatting' do
+    let(:workshop) { double(:workshop, time: Time.zone.now, ends_at: 1.hour.from_now) }
 
-  it '#end_time' do
-    expect(workshop.end_time).to eq(I18n.l(workshop_double.ends_at, format: :time))
-  end
+    it '#time' do
+      start_time = workshop.time
 
-  context 'start_and_end_time' do
-    it 'when no end_time is set it only returns the start_time' do
-      workshop_double =  double(:workshop, time: Time.zone.now, ends_at: nil)
-      workshop = WorkshopPresenter.new(workshop_double)
-
-      expect(workshop.start_and_end_time).to eq(I18n.l(workshop_double.time, format: :time))
+      expect(presenter.time).to eq(I18n.l(start_time, format: :time))
     end
 
-    it 'when a start and end_time are set it returns a formatted start and end_time' do
-      workshop_double =  double(:workshop, time: Time.zone.now, ends_at: 1.hour.from_now)
-      workshop = WorkshopPresenter.new(workshop_double)
+    it '#end_time' do
+      expect(presenter.end_time).to eq(I18n.l(workshop.ends_at, format: :time))
+    end
 
-      expect(workshop.start_and_end_time)
-        .to eq("#{I18n.l(workshop_double.time, format: :time)} - #{I18n.l(workshop_double.ends_at, format: :time)}")
+    context '#start_and_end_time' do
+      it 'when no end_time is set it only returns the start_time' do
+        workshop =  double(:workshop, time: Time.zone.now, ends_at: nil)
+        presenter = WorkshopPresenter.new(workshop)
+
+        expect(presenter.start_and_end_time).to eq(I18n.l(workshop.time, format: :time))
+      end
+
+      it 'when a start and end_time are set it returns a formatted start and end_time' do
+        workshop =  double(:workshop, time: Time.zone.now, ends_at: 1.hour.from_now)
+        presenter = WorkshopPresenter.new(workshop)
+
+        expect(presenter.start_and_end_time)
+          .to eq("#{I18n.l(workshop.time, format: :time)} - #{I18n.l(workshop.ends_at, format: :time)}")
+      end
     end
   end
 
-  it '#attendees_csv' do
-    expect(workshop).to receive(:organisers).at_least(:once).and_return [invitations.last.member]
-    expect(workshop.attendees_csv).not_to be_blank
-
-    invitations.each do |invitation|
-      expect(workshop.attendees_csv).to include(invitation.member.full_name)
-      expect(workshop.attendees_csv).to include(invitation.role.upcase).or include('ORGANISER')
+  context '#attendees_csv' do
+    let(:invitations) do
+      [Fabricate.times(2, :student_workshop_invitation), Fabricate.times(2, :coach_workshop_invitation)].flatten
     end
-    expect(workshop.attendees_csv).to include('ORGANISER')
-    expect(workshop.attendees_csv).to include('STUDENT')
-    expect(workshop.attendees_csv).to include('COACH')
+    let(:workshop) { double(:workshop, attendances: invitations) }
+
+    it 'correctly returns the formatted list of workshop participants' do
+      expect(presenter).to receive(:organisers).at_least(:once).and_return [invitations.last.member]
+      expect(presenter.attendees_csv).not_to be_blank
+
+      invitations.each do |invitation|
+        expect(presenter.attendees_csv).to include(invitation.member.full_name)
+        expect(presenter.attendees_csv).to include(invitation.role.upcase).or include('ORGANISER')
+      end
+      expect(presenter.attendees_csv).to include('ORGANISER')
+      expect(presenter.attendees_csv).to include('STUDENT')
+      expect(presenter.attendees_csv).to include('COACH')
+    end
   end
 
   it '#attendees_emails' do
@@ -71,8 +74,8 @@ RSpec.describe WorkshopPresenter do
     presenter = WorkshopPresenter.new(workshop)
     members = Fabricate.times(6, :member)
     members.each_with_index do |member, index|
-      index % 2 == 0 ? Fabricate(:attending_workshop_invitation, member: member,  workshop: workshop) :
-                       Fabricate(:attending_workshop_invitation, member: member,  workshop: workshop, role: 'Coach')
+      index % 2 == 0 ? Fabricate(:attending_workshop_invitation, member: member, workshop: workshop) :
+        Fabricate(:attending_workshop_invitation, member: member, workshop: workshop, role: 'Coach')
     end
 
     expect(presenter.attendees_emails.split(', ')).to match_array(members.map(&:email))

--- a/spec/support/shared_examples/managing_workshop_attendance.rb
+++ b/spec/support/shared_examples/managing_workshop_attendance.rb
@@ -1,0 +1,176 @@
+RSpec.shared_examples 'managing workshop attendance' do
+  context 'a logged in member' do
+    context '#upcoming workshop' do
+      context 'via the workshop page' do
+        context 'with only student subscriptions' do
+          before do
+            login(student)
+            visit workshop_path(workshop)
+          end
+
+          it 'can only RSVP as a student' do
+            click_on 'Attend as a student'
+            click_on 'Attend'
+
+            expect(page).to have_content('See you at the workshop')
+
+            visit workshop_path(workshop)
+            expect(page).to have_button('Manage your invitation')
+          end
+
+          it 'cannot RSVP as a coach' do
+            expect(page).not_to have_content('Attend as a coach')
+          end
+        end
+
+        context 'with only coach subscriptions' do
+          before do
+            login(coach)
+            visit workshop_path(workshop)
+          end
+
+          it 'can only RSVP as a coach' do
+            click_on 'Attend as a coach'
+            click_on 'Attend'
+
+            expect(page).to have_content('See you at the workshop')
+
+            visit workshop_path(workshop)
+            expect(page).to have_button('Manage your invitation')
+          end
+
+          it 'cannot RSVP as a student' do
+            expect(page).not_to have_content('Attend as a student')
+          end
+        end
+
+        context 'with both coach and student subscriptions' do
+          before do
+            kara = Fabricate(:student)
+            coaches = Fabricate(:coaches)
+            kara.groups << coaches
+            login(kara)
+            visit workshop_path(workshop)
+          end
+
+          it 'can get to the RSVP as a student page' do
+            click_on 'Attend as a student'
+            click_on 'Attend'
+
+            expect(page).to have_content('See you at the workshop')
+
+            visit workshop_path(workshop)
+            expect(page).to have_button('Manage your invitation')
+          end
+
+          it 'can get to the RSVP as a coach page' do
+            click_on 'Attend as a coach'
+            click_on 'Attend'
+
+            expect(page).to have_content('See you at the workshop')
+
+            visit workshop_path(workshop)
+            expect(page).to have_button('Manage your invitation')
+          end
+        end
+
+        context 'who has already RSVPed' do
+          let(:student) { Fabricate(:student) }
+
+          before do
+            coaches = Fabricate(:coaches)
+            student.groups << coaches
+            login(student)
+          end
+
+          it 'can get back to their invitation page' do
+            visit workshop_path(workshop)
+
+            click_on 'Attend as a coach'
+            click_on 'Attend'
+
+            visit workshop_path(workshop)
+
+            click_on 'Manage your invitation'
+            expect(page).to have_content("Hi #{student.name}")
+            expect(page).to have_content('You should also go through our coaching guide')
+          end
+        end
+
+        context 'with no subscriptions' do
+          before do
+            no_subs = Fabricate(:member)
+            login(no_subs)
+            visit workshop_path(workshop)
+          end
+
+          it 'will be prompted to manage their subscriptions' do
+            expect(page).to have_content('Please tell us whether you want to attend as a student or coach.')
+
+            click_link 'Please tell us whether you want to attend as a student or coach.'
+            expect(page).to have_current_path(subscriptions_path)
+          end
+
+          it 'cannot access RSVP as a student or coach' do
+            expect(page).not_to have_content('Attend as a student')
+            expect(page).not_to have_content('Attend as a coach')
+          end
+        end
+      end
+
+      context 'managing invitations' do
+        before do
+          login(coach)
+          visit workshop_path(workshop)
+        end
+
+        context 'when auto RSVP open time is past, invitable turned off' do
+          it 'can access RSVP as a coach' do
+            visit workshop_path(workshop_auto_rsvp_in_past)
+
+            click_on 'Attend as a coach'
+            click_on 'Attend'
+
+            expect(page).to have_content('See you at the workshop')
+          end
+
+          after do
+            visit workshop_path(workshop_auto_rsvp_in_past)
+            expect(page).to have_button('Manage your invitation')
+          end
+        end
+
+        context 'when auto RSVP open time is future, invitable turned off' do
+          it 'cannot access RSVP as a student or coach' do
+            visit workshop_path(workshop_auto_rsvp_in_future)
+
+            expect(page).to have_content('This workshop is not yet open for RSVP.')
+          end
+        end
+
+        context 'when invitations have been sent out' do
+          let(:member) { Fabricate(:member) }
+          let!(:invitation) { Fabricate(:attending_workshop_invitation, member: member, workshop: workshop) }
+
+          it 'can manage details if they are already attending' do
+            login(member)
+            visit workshop_path(workshop)
+
+            expect(page).to have_button('Manage your invitation')
+            expect(page).not_to have_link('Attend as a student')
+            expect(page).not_to have_link('Attend as a coach')
+          end
+        end
+      end
+    end
+
+    context '#past workshop' do
+      let(:workshop) { Fabricate(:workshop, date_and_time: 2.weeks.ago) }
+
+      scenario 'cannot interact with a past event' do
+        visit workshop_path(workshop)
+        expect(page).to have_content('has already taken place')
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/viewing_workshop_actions.rb
+++ b/spec/support/shared_examples/viewing_workshop_actions.rb
@@ -1,0 +1,6 @@
+RSpec.shared_examples 'viewing workshop actions' do
+  scenario 'signing up or signing in' do
+    expect(page).to have_content('Sign up')
+    expect(page).to have_content('Log in')
+  end
+end

--- a/spec/support/shared_examples/viewing_workshop_details.rb
+++ b/spec/support/shared_examples/viewing_workshop_details.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples 'viewing workshop details' do
+  scenario 'sponsors' do
+    within '#sponsors' do
+      workshop.sponsors.each do |sponsor|
+        expect(page).to have_content(sponsor.name)
+      end
+    end
+  end
+
+  scenario 'organisers' do
+    within '#organisers' do
+      expect(page).to have_content('Organisers')
+
+      workshop.organisers.each do |organiser|
+        expect(page).to have_content(organiser.full_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#TODO

- Render a more descriptive title for the workshop in the landing and event listing pages
- Add field to store slack channel and slack channel link for virtual workshops and update workshop invitation to display that on anyone attending
- Update attending virtual workshop confirmation email to link to 'How to join workshop' area on invitation
- Add some tests and either new emails or email tweaks for for virtual workshop waiting list,  attendance reminder, invite_coach and invite_student